### PR TITLE
Fix copying of public address of wallets

### DIFF
--- a/app/createwallet/page.tsx
+++ b/app/createwallet/page.tsx
@@ -190,7 +190,7 @@ export default function CreateWallet ({nemonic}:any) {
 
 
        <div className="pt-10">
-            <div className="flex justify-center relative z-[-1] flex place-items-center  before:absolute before:h-[300px] before:w-full before:-translate-x-1/2 before:rounded-full before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl before:content-[''] after:absolute after:-z-20 after:h-[180px] after:w-full after:translate-x-1/3 after:bg-gradient-conic after:from-sky-200 after:via-blue-200 after:blur-2xl after:content-[''] before:dark:bg-gradient-to-br before:dark:from-transparent before:dark:to-blue-700 before:dark:opacity-10 after:dark:from-sky-900 after:dark:via-[#0141ff] after:dark:opacity-40 sm:before:w-[480px] sm:after:w-[240px] before:lg:h-[360px]">
+            <div className="flex justify-center relative flex place-items-center  before:absolute before:h-[300px] before:w-full before:-translate-x-1/2 before:rounded-full before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl before:content-[''] after:absolute after:-z-20 after:h-[180px] after:w-full after:translate-x-1/3 after:bg-gradient-conic after:from-sky-200 after:via-blue-200 after:blur-2xl after:content-[''] before:dark:bg-gradient-to-br before:dark:from-transparent before:dark:to-blue-700 before:dark:opacity-10 after:dark:from-sky-900 after:dark:via-[#0141ff] after:dark:opacity-40 sm:before:w-[480px] sm:after:w-[240px] before:lg:h-[360px]">
                 <div className="border border-zinc-700 flex justify-center h-full w-auto sm:w-full p-4 ">
                         <div className="relative drop-shadow-[0_0_0.3rem_#ffffff70] invert"/>
                             <div className="flex justify-center p-8">

--- a/components/ui/walletCard.tsx
+++ b/components/ui/walletCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import ContentCopyOutlinedIcon from "@mui/icons-material/ContentCopyOutlined";
 import RemoveRedEyeOutlinedIcon from "@mui/icons-material/RemoveRedEyeOutlined";
+import { ArrowLeft, Copy, Check, X } from 'lucide-react';
 
 interface CardProps {
   balance: string;
@@ -10,6 +11,7 @@ interface CardProps {
 
 export const WalletCard: React.FC<CardProps> = ({ balance, publicKey, privateKey }) => {
   const [showPrivateKey, setShowPrivateKey] = useState(false);
+  const [copiedText, setCopiedText] = useState<string | null>(null);
 
   const shortPublicKey = `${publicKey.slice(0, 6)}...${publicKey.slice(-6)}`;
   const shortPrivateKey = `${privateKey.slice(0, 6)}...${privateKey.slice(-6)}`;
@@ -17,7 +19,8 @@ export const WalletCard: React.FC<CardProps> = ({ balance, publicKey, privateKey
   const copyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text)
         .then(() => {
-            alert("Copied to clipboard!");
+          setCopiedText(text);
+          setTimeout(() => setCopiedText(null), 2000);
         })
         .catch((err) => {
             alert("Failed to copy to clipboard");
@@ -31,7 +34,7 @@ export const WalletCard: React.FC<CardProps> = ({ balance, publicKey, privateKey
     <div>
       <div className="flex justify-center">
         <div className="flex justify-center w-fit h-full border border-zinc-800 p-2 rounded">
-          <div className="relative z-[-1] flex place-items-center">
+          <div className="relative flex place-items-center">
             <div>
               <div className="pb-16">
                 <p className="flex justify-center bg-slate-800 p-2 font-bold text-xl rounded">
@@ -44,11 +47,13 @@ export const WalletCard: React.FC<CardProps> = ({ balance, publicKey, privateKey
                 <p className="text-sm">Public Key</p>
                 <div className="flex justify-between w-full h-full border border-zinc-800 rounded p-1 gap-2">
                   <div>{shortPublicKey}</div>
-                  <div onClick={()=>copyToClipboard(publicKey)}>
-                  
-                    <ContentCopyOutlinedIcon/>
-                 
-                  </div>
+                  <button onClick={()=>copyToClipboard(publicKey)}>
+                    {copiedText ? (
+                      <Check size={25} className='text-green-600' />
+                    ) : (
+                      <ContentCopyOutlinedIcon />
+                    )}
+                  </button>
                 
                 </div>
               </div>
@@ -69,9 +74,9 @@ export const WalletCard: React.FC<CardProps> = ({ balance, publicKey, privateKey
       </div>
 
       {showPrivateKey && (
-        <div className="fixed inset-0 flex items-center justify-center z-50">
+        <div className="fixed inset-0 flex items-center justify-center">
           <div className="fixed inset-0 bg-black opacity-50" onClick={toggleModal}></div>
-          <div className="bg-slate-900 p-6 w-full rounded shadow-lg z-50">
+          <div className="bg-slate-900 p-6 w-full rounded shadow-lg">
             <h2 className="text-lg font-bold mb-4">Private Key</h2>
             <p className="mb-4">{privateKey}</p>
             <button


### PR DESCRIPTION
Fixes #18 

Issue
improper z index was covering the div behind other elements, thus preventing any click interaction in that div - made user unable to copy the public address and see the private key

Changes Implemented
Adjusting z index so now
Public address can be copied successfully and stored in a declared variable to be able to access it, and instead of alert, follow the standard copying button,
Nor private key can be seen as well

If my changes seem fine, please label the pr with "gssoc-ext" and level

Here is a preview of the changes made

https://github.com/user-attachments/assets/8425e958-cf90-46b3-b6ff-2216eacb0dca

